### PR TITLE
SystemV: unified template for RH/Debian-like and LSB systems

### DIFF
--- a/service.go
+++ b/service.go
@@ -59,7 +59,7 @@
 //			logger.Error(err)
 //		}
 //	}
-package service // import "github.com/kardianos/service"
+package service
 
 import (
 	"errors"

--- a/service_linux.go
+++ b/service_linux.go
@@ -31,14 +31,14 @@ func (sc linuxSystemService) New(i Interface, c *Config) (Service, error) {
 
 func init() {
 	ChooseSystem(linuxSystemService{
-		name:   "linux-systemd",
-		detect: isSystemd,
-		interactive: func() bool {
-			is, _ := isInteractive()
-			return is
+			name:   "linux-systemd",
+			detect: isSystemd,
+			interactive: func() bool {
+				is, _ := isInteractive()
+				return is
+			},
+			new: newSystemdService,
 		},
-		new: newSystemdService,
-	},
 		linuxSystemService{
 			name:   "linux-upstart",
 			detect: isUpstart,
@@ -68,5 +68,15 @@ func isInteractive() (bool, error) {
 var tf = map[string]interface{}{
 	"cmd": func(s string) string {
 		return `"` + strings.Replace(s, `"`, `\"`, -1) + `"`
+	},
+	"join": func(items []string, sep string) string {
+		switch len(items) {
+		case 0:
+			return ""
+		case 1:
+			return items[0]
+		default:
+			return strings.Join(items, sep)
+		}
 	},
 }

--- a/service_linux.go
+++ b/service_linux.go
@@ -7,6 +7,7 @@ package service
 import (
 	"os"
 	"strings"
+	"regexp"
 )
 
 type linuxSystemService struct {
@@ -67,7 +68,11 @@ func isInteractive() (bool, error) {
 
 var tf = map[string]interface{}{
 	"cmd": func(s string) string {
-		return `"` + strings.Replace(s, `"`, `\"`, -1) + `"`
+		s = strings.TrimSpace(s)
+		if needsQuotes, _ := regexp.MatchString(`\s+`, s); needsQuotes {
+			return `"` + strings.Replace(s, `"`, `\"`, -1) + `"`
+		}
+		return s
 	},
 	"join": func(items []string, sep string) string {
 		switch len(items) {

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -157,12 +157,13 @@ func (s *systemd) Restart() error {
 
 const systemdScript = `[Unit]
 Description={{.Description}}
-ConditionFileIsExecutable={{.Path|cmd}}
+After=syslog.target network.target
+ConditionFileIsExecutable={{.Path}}
 
 [Service]
 StartLimitInterval=5
 StartLimitBurst=10
-ExecStart={{.Path|cmd}}{{range .Arguments}} {{.|cmd}}{{end}}
+ExecStart={{.Path}}{{range .Arguments}} {{.|cmd}}{{end}}
 {{if .ChRoot}}RootDirectory={{.ChRoot|cmd}}{{end}}
 {{if .WorkingDirectory}}WorkingDirectory={{.WorkingDirectory|cmd}}{{end}}
 {{if .UserName}}User={{.UserName}}{{end}}

--- a/service_sysv_linux.go
+++ b/service_sysv_linux.go
@@ -286,9 +286,6 @@ LOCKFILE="/var/lock/subsys/${NAME}"
 STDOUTLOG="/dev/null"
 STDERRLOG="/dev/null"
 
-# Startup options
-DAEMON_ARGS="{{range .Arguments}} {{.|cmd}}{{end}}"
-
 # Source configuration defaults to override above as appropriate.
 ! test -e /etc/default/${NAME}   || . /etc/default/${NAME}
 ! test -e /etc/sysconfig/${NAME} || . /etc/sysconfig/${NAME}
@@ -304,7 +301,7 @@ start() {
     get_status &>/dev/null && return 0
     echo -n $"Starting ${DESC}: "
     daemon --pidfile="$PIDFILE" {{if .UserName}}--user={{.UserName}}{{end}} \
-	   "$CMD $DAEMON_ARGS </dev/null >$STDOUTLOG 2>$STDERRLOG & echo \$! > $PIDFILE"
+	   "$CMD {{range .Arguments}} {{.|cmd}}{{end}} </dev/null >$STDOUTLOG 2>$STDERRLOG & echo \$! > $PIDFILE"
     sleep 0.5 # wait briefly to see if service failed to start
     get_status &>/dev/null && success || failure
     RETVAL=$?
@@ -350,7 +347,7 @@ start() {
     --pidfile "$PIDFILE" \
     --background \
     --make-pidfile \
-    --exec "$CMD" -- "$DAEMON_ARGS"
+    --exec "$CMD" -- {{range .Arguments}} {{.|cmd}}{{end}}
     log_end_msg  $?
 }
 
@@ -365,7 +362,7 @@ start() {
     get_status &>/dev/null && return 0
     echo -n $"Starting $DESC: ${NAME}"
     {{if .WorkingDirectory}}cd {{.WorkingDirectory|cmd}}{{end}}
-    "$CMD" "$DAEMON_ARGS" </dev/null >"$STDOUTLOG" 2>"$STDERRLOG" &
+    "$CMD" {{range .Arguments}} {{.|cmd}}{{end}} </dev/null >"$STDOUTLOG" 2>"$STDERRLOG" &
     echo $! > "$PIDFILE"
     sleep 0.5 # wait briefly to see if service crashed
     get_status &>/dev/null

--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -168,5 +168,8 @@ pre-start script
 end script
 
 # Start
-exec {{.Path}}{{range .Arguments}} {{.|cmd}}{{end}}
+# Due to bug in Precise Upstart this is the only way to inherit user groups
+# http://upstart.ubuntu.com/cookbook/#changing-user
+exec start-stop-daemon --start {{if .UserName}}-c {{.UserName|cmd}}{{end}} {{if .WorkingDirectory}}-d {{.WorkingDirectory|cmd}}{{end}} --exec {{.Path}} -- {{range .Arguments}} {{.|cmd}}{{end}}
 `
+


### PR DESCRIPTION
This patch makes SysV handling consistent across RH/Debian and LSB systems,
following discussion wity @ayufan. Tested on ubuntu 12.04, 14.04; debian
6.0.10, 7.9, 8.1; Red Hat 6.4 and 7.0 (RH5 is not supported by go).

To support non-LSB systems requires to solve again problems that are already addressed in

  http://refspecs.linuxbase.org/LSB_3.1.0/LSB-Core-generic/LSB-Core-generic/iniscrptfunc.html

It boils down to not solve the problems as adequately as in LSB. That is the choice is between
 a) implement LSB-like functionality, which reinvents the wheel and may not be as robust; or
 b) copy LSB functions into the script template, which would greatly increase its size.

Hence I think it is better to exit with a warning, asking to install a copy of init-functions.

The strategy of the template is now
1. if RH functions exist, make use of them, else
2. if no LSB functions exist (even Debian/Ubuntu require them), exit with a message, else
3. if start-stop-daemon is in $PATH, proceed as if it is a Debian-like system, else
4. fall back to LSB functions to start/stop the service.

Other than that, these are the minor changes to the template:
- debian script:
  - renamed do_{start,stop} to start,stop for consistency
  - the stop() function used --chuid, which is only active when the
    --start option is specified (as per manpage); removed it
  - replaced error message when not running as root with exit 4 ("user
    had insufficient privilege", as per
    http://refspecs.linuxbase.org/LSB_3.1.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html)
  - the $DAEMON variable used by status was not declared, now using $CMD
  - when running 'stop' twice, it complained that the pidfile still exists: added 'rm $pidfile'
- RH script:
  - moved the rh_status_q tests directly into the start/stop functions
  - RH's daemon() function in /etc/init.d/functions does not support --chdir; removed it
  - fixed the following issue:
    -- using daemon with a background job causes $? to always be 0, an explanation is at
       http://stackoverflow.com/questions/21742227/redhat-daemon-function-usage
    -- worked around this by (a) adding small sleep and (b) explicitly checking status
  - removed condrestart / try-restart
    apart from checking the status, there was no subsequent action,
    i.e. condrestart / try-restart currently did not accomplish anything.
  - tested the reload function and decided to remove it, reasons:
    -- using kill -HUP to mean 'reload' works only if the program has a signal handler,
    -- if it does not, it may kill the service
    -- this means reload will only work for a few programs and will cause problems for others
    -- we could support it later, e.g. by {{if ne .ReloadSignal ""}} <code>{{end}}
  - refactored rh_status_q, expanding it made code simpler
  - added the chkconfig runlevels corresponding to current implementation (S50, K02)
  - verified that chkconfig(8) does not support the 'processname:' header, removed it
