### PR TITLE
Replacement of $DAEMON

### DIFF
--- a/service_sysv_linux.go
+++ b/service_sysv_linux.go
@@ -346,7 +346,7 @@ case "$1" in
     $0 start
     ;;
   status)
-    status_of_proc -p "$PIDFILE" "$DAEMON" "$DESC"
+    status_of_proc -p "$PIDFILE" "$NAME" "$DESC"
     ;;
   *)
     echo "Usage: sudo service $0 {start|stop|restart|status}" >&2


### PR DESCRIPTION
Changing $DAEMON to $NAME as $DAEMON doesn't exists.
The PR is need to ensure that `gitlab-runner status` and `service gitlab-runner status` give a valid status